### PR TITLE
Deprecate some CSS logical property utilities

### DIFF
--- a/api-extractor/emotion-utils.api.json
+++ b/api-extractor/emotion-utils.api.json
@@ -172,7 +172,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!borderInlineEndWidth:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width | border-inline-end-width} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties | logical properties} aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width | border-inline-end-width} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with native border-inline-end-width.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -198,7 +198,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!borderInlineStartWidth:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width | border-inline-start-width} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties | logical properties} aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width | border-inline-start-width} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with native border-inline-start-width.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -328,7 +328,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!marginInlineEnd:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end | margin-inline-end} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 logical properties aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end | margin-inline-end} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with native margin-inline-end.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -354,7 +354,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!marginInlineStart:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start | margin-inline-start} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 logical properties aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start | margin-inline-start} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with margin-inline-start.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -432,7 +432,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!paddingInlineEnd:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end | padding-inline-end} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 logical properties aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end | padding-inline-end} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with native padding-inline-end.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -458,7 +458,7 @@
         {
           "kind": "Variable",
           "canonicalReference": "@asl-19/emotion-utils!paddingInlineStart:var",
-          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start | padding-inline-start} CSS property.\n *\n * @remarks\n *\n * As of 2020-05 logical properties aren’t pervasive enough to use on their own.\n *\n * @public\n */\n",
+          "docComment": "/**\n * Equivalent to the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start | padding-inline-start} CSS property. [DEPRECATED]\n *\n * @deprecated\n *\n * Should be replaced with native padding-inline-start.\n *\n * @public\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/api-extractor/emotion-utils.api.md
+++ b/api-extractor/emotion-utils.api.md
@@ -6,10 +6,10 @@
 
 import { SerializedStyles } from '@emotion/react';
 
-// @public
+// @public @deprecated
 export const borderInlineEndWidth: (value: string) => SerializedStyles;
 
-// @public
+// @public @deprecated
 export const borderInlineStartWidth: (value: string) => SerializedStyles;
 
 // @public
@@ -24,10 +24,10 @@ export const marginBlock: (value: string) => SerializedStyles;
 // @public
 export const marginInline: (value: string) => SerializedStyles;
 
-// @public
+// @public @deprecated
 export const marginInlineEnd: (value: string) => SerializedStyles;
 
-// @public
+// @public @deprecated
 export const marginInlineStart: (value: string) => SerializedStyles;
 
 // @public
@@ -36,11 +36,10 @@ export const paddingBlock: (value: string) => SerializedStyles;
 // @public
 export const paddingInline: (value: string) => SerializedStyles;
 
-// @public
+// @public @deprecated
 export const paddingInlineEnd: (value: string) => SerializedStyles;
 
-// @public
+// @public @deprecated
 export const paddingInlineStart: (value: string) => SerializedStyles;
-
 
 ```

--- a/docs/emotion-utils.borderinlineendwidth.md
+++ b/docs/emotion-utils.borderinlineendwidth.md
@@ -4,15 +4,15 @@
 
 ## borderInlineEndWidth variable
 
-Equivalent to the [border-inline-end-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with native border-inline-end-width.
+> 
+
+Equivalent to the [border-inline-end-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 borderInlineEndWidth: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) aren’t pervasive enough to use on their own.
-

--- a/docs/emotion-utils.borderinlinestartwidth.md
+++ b/docs/emotion-utils.borderinlinestartwidth.md
@@ -4,15 +4,15 @@
 
 ## borderInlineStartWidth variable
 
-Equivalent to the [border-inline-start-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with native border-inline-start-width.
+> 
+
+Equivalent to the [border-inline-start-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 borderInlineStartWidth: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) aren’t pervasive enough to use on their own.
-

--- a/docs/emotion-utils.margininlineend.md
+++ b/docs/emotion-utils.margininlineend.md
@@ -4,15 +4,15 @@
 
 ## marginInlineEnd variable
 
-Equivalent to the [margin-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with native margin-inline-end.
+> 
+
+Equivalent to the [margin-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 marginInlineEnd: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 logical properties aren’t pervasive enough to use on their own.
-

--- a/docs/emotion-utils.margininlinestart.md
+++ b/docs/emotion-utils.margininlinestart.md
@@ -4,15 +4,15 @@
 
 ## marginInlineStart variable
 
-Equivalent to the [margin-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with margin-inline-start.
+> 
+
+Equivalent to the [margin-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 marginInlineStart: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 logical properties aren’t pervasive enough to use on their own.
-

--- a/docs/emotion-utils.md
+++ b/docs/emotion-utils.md
@@ -10,16 +10,16 @@ A collection of Emotion utility functions.
 
 |  Variable | Description |
 |  --- | --- |
-|  [borderInlineEndWidth](./emotion-utils.borderinlineendwidth.md) | Equivalent to the [border-inline-end-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) CSS property. |
-|  [borderInlineStartWidth](./emotion-utils.borderinlinestartwidth.md) | Equivalent to the [border-inline-start-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) CSS property. |
+|  [borderInlineEndWidth](./emotion-utils.borderinlineendwidth.md) | Equivalent to the [border-inline-end-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) CSS property. \[DEPRECATED\] |
+|  [borderInlineStartWidth](./emotion-utils.borderinlinestartwidth.md) | Equivalent to the [border-inline-start-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) CSS property. \[DEPRECATED\] |
 |  [insetInlineEnd](./emotion-utils.insetinlineend.md) | Equivalent to the [inset-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end) CSS property. |
 |  [insetInlineStart](./emotion-utils.insetinlinestart.md) | Equivalent to the [inset-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start) CSS property. |
 |  [marginBlock](./emotion-utils.marginblock.md) | Equivalent to the [margin-block](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block) CSS property. |
 |  [marginInline](./emotion-utils.margininline.md) | Equivalent to the [margin-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline) CSS property. |
-|  [marginInlineEnd](./emotion-utils.margininlineend.md) | Equivalent to the [margin-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) CSS property. |
-|  [marginInlineStart](./emotion-utils.margininlinestart.md) | Equivalent to the [margin-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) CSS property. |
+|  [marginInlineEnd](./emotion-utils.margininlineend.md) | Equivalent to the [margin-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) CSS property. \[DEPRECATED\] |
+|  [marginInlineStart](./emotion-utils.margininlinestart.md) | Equivalent to the [margin-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) CSS property. \[DEPRECATED\] |
 |  [paddingBlock](./emotion-utils.paddingblock.md) | Equivalent to the [padding-block](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block) CSS property. |
 |  [paddingInline](./emotion-utils.paddinginline.md) | Equivalent to the [padding-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline) CSS property. |
-|  [paddingInlineEnd](./emotion-utils.paddinginlineend.md) | Equivalent to the [padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) CSS property. |
-|  [paddingInlineStart](./emotion-utils.paddinginlinestart.md) | Equivalent to the [padding-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) CSS property. |
+|  [paddingInlineEnd](./emotion-utils.paddinginlineend.md) | Equivalent to the [padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) CSS property. \[DEPRECATED\] |
+|  [paddingInlineStart](./emotion-utils.paddinginlinestart.md) | Equivalent to the [padding-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) CSS property. \[DEPRECATED\] |
 

--- a/docs/emotion-utils.paddinginlineend.md
+++ b/docs/emotion-utils.paddinginlineend.md
@@ -4,15 +4,15 @@
 
 ## paddingInlineEnd variable
 
-Equivalent to the [padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with native padding-inline-end.
+> 
+
+Equivalent to the [padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 paddingInlineEnd: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 logical properties aren’t pervasive enough to use on their own.
-

--- a/docs/emotion-utils.paddinginlinestart.md
+++ b/docs/emotion-utils.paddinginlinestart.md
@@ -4,15 +4,15 @@
 
 ## paddingInlineStart variable
 
-Equivalent to the [padding-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) CSS property.
+> Warning: This API is now obsolete.
+> 
+> Should be replaced with native padding-inline-start.
+> 
+
+Equivalent to the [padding-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) CSS property. \[DEPRECATED\]
 
 <b>Signature:</b>
 
 ```typescript
 paddingInlineStart: (value: string) => SerializedStyles
 ```
-
-## Remarks
-
-As of 2020-05 logical properties aren’t pervasive enough to use on their own.
-

--- a/src/borderInlineEndWidth.ts
+++ b/src/borderInlineEndWidth.ts
@@ -3,22 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width|border-inline-end-width}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05
- * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties|logical properties}
- * aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native border-inline-end-width.
  * @public
  */
-const borderInlineEndWidth = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    border-right-width: ${value};
-  }
-  html[dir="rtl"] & {
-    border-left-width: ${value};
-  }
-`;
+const borderInlineEndWidth = (value: string): SerializedStyles => {
+  console.info(
+    "borderInlineEndWidth is deprecated due to pervasive browser support for the native border-inline-end-width property. Please replace with border-inline-end-width."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      border-right-width: ${value};
+    }
+    html[dir="rtl"] & {
+      border-left-width: ${value};
+    }
+  `;
+};
 
 export default borderInlineEndWidth;

--- a/src/borderInlineStartWidth.ts
+++ b/src/borderInlineStartWidth.ts
@@ -3,22 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width|border-inline-start-width}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05
- * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties|logical properties}
- * aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native border-inline-start-width.
  * @public
  */
-const borderInlineStartWidth = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    border-left-width: ${value};
-  }
-  html[dir="rtl"] & {
-    border-right-width: ${value};
-  }
-`;
+const borderInlineStartWidth = (value: string): SerializedStyles => {
+  console.info(
+    "borderInlineStartWidth is deprecated due to pervasive browser support for the native border-inline-start-width property. Please replace with border-inline-start-width."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      border-left-width: ${value};
+    }
+    html[dir="rtl"] & {
+      border-right-width: ${value};
+    }
+  `;
+};
 
 export default borderInlineStartWidth;

--- a/src/marginInlineEnd.ts
+++ b/src/marginInlineEnd.ts
@@ -3,20 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end|margin-inline-end}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native margin-inline-end.
  * @public
  */
-const marginInlineEnd = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    margin-right: ${value};
-  }
-  html[dir="rtl"] & {
-    margin-left: ${value};
-  }
-`;
+const marginInlineEnd = (value: string): SerializedStyles => {
+  console.info(
+    "marginInlineEnd is deprecated due to pervasive browser support for the native margin-inline-end property. Please replace with margin-inline-end."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      margin-right: ${value};
+    }
+    html[dir="rtl"] & {
+      margin-left: ${value};
+    }
+  `;
+};
 
 export default marginInlineEnd;

--- a/src/marginInlineStart.ts
+++ b/src/marginInlineStart.ts
@@ -3,20 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start|margin-inline-start}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with margin-inline-start.
  * @public
  */
-const marginInlineStart = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    margin-left: ${value};
-  }
-  html[dir="rtl"] & {
-    margin-right: ${value};
-  }
-`;
+const marginInlineStart = (value: string): SerializedStyles => {
+  console.info(
+    "marginInlineStart is deprecated due to pervasive browser support for the native margin-inline-start property. Please replace with margin-inline-start."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      margin-left: ${value};
+    }
+    html[dir="rtl"] & {
+      margin-right: ${value};
+    }
+  `;
+};
 
 export default marginInlineStart;

--- a/src/paddingInlineEnd.ts
+++ b/src/paddingInlineEnd.ts
@@ -3,20 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end|padding-inline-end}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native padding-inline-end.
  * @public
  */
-const paddingInlineEnd = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    padding-right: ${value};
-  }
-  html[dir="rtl"] & {
-    padding-left: ${value};
-  }
-`;
+const paddingInlineEnd = (value: string): SerializedStyles => {
+  console.info(
+    "paddingInlineEnd is deprecated due to pervasive browser support for the native padding-inline-end property. Please replace with padding-inline-end."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      padding-right: ${value};
+    }
+    html[dir="rtl"] & {
+      padding-left: ${value};
+    }
+  `;
+};
 
 export default paddingInlineEnd;

--- a/src/paddingInlineStart.ts
+++ b/src/paddingInlineStart.ts
@@ -3,20 +3,24 @@ import { css, SerializedStyles } from "@emotion/react";
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start|padding-inline-start}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native padding-inline-start.
  * @public
  */
-const paddingInlineStart = (value: string): SerializedStyles => css`
-  html[dir="ltr"] & {
-    padding-left: ${value};
-  }
-  html[dir="rtl"] & {
-    padding-right: ${value};
-  }
-`;
+const paddingInlineStart = (value: string): SerializedStyles => {
+  console.info(
+    "paddingInlineStart is deprecated due to pervasive browser support for the native padding-inline-start property. Please replace with padding-inline-start."
+  );
+
+  return css`
+    html[dir="ltr"] & {
+      padding-left: ${value};
+    }
+    html[dir="rtl"] & {
+      padding-right: ${value};
+    }
+  `;
+};
 
 export default paddingInlineStart;

--- a/types/emotion-utils.d.ts
+++ b/types/emotion-utils.d.ts
@@ -9,13 +9,9 @@ import { SerializedStyles } from '@emotion/react';
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width|border-inline-end-width}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05
- * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties|logical properties}
- * aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native border-inline-end-width.
  * @public
  */
 export declare const borderInlineEndWidth: (value: string) => SerializedStyles;
@@ -23,13 +19,9 @@ export declare const borderInlineEndWidth: (value: string) => SerializedStyles;
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width|border-inline-start-width}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05
- * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties|logical properties}
- * aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native border-inline-start-width.
  * @public
  */
 export declare const borderInlineStartWidth: (value: string) => SerializedStyles;
@@ -87,11 +79,9 @@ export declare const marginInline: (value: string) => SerializedStyles;
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end|margin-inline-end}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native margin-inline-end.
  * @public
  */
 export declare const marginInlineEnd: (value: string) => SerializedStyles;
@@ -99,11 +89,9 @@ export declare const marginInlineEnd: (value: string) => SerializedStyles;
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start|margin-inline-start}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with margin-inline-start.
  * @public
  */
 export declare const marginInlineStart: (value: string) => SerializedStyles;
@@ -135,11 +123,9 @@ export declare const paddingInline: (value: string) => SerializedStyles;
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end|padding-inline-end}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native padding-inline-end.
  * @public
  */
 export declare const paddingInlineEnd: (value: string) => SerializedStyles;
@@ -147,11 +133,9 @@ export declare const paddingInlineEnd: (value: string) => SerializedStyles;
 /**
  * Equivalent to the
  * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start|padding-inline-start}
- * CSS property.
+ * CSS property. [DEPRECATED]
  *
- * @remarks
- * As of 2020-05 logical properties aren’t pervasive enough to use on their own.
- *
+ * @deprecated Should be replaced with native padding-inline-start.
  * @public
  */
 export declare const paddingInlineStart: (value: string) => SerializedStyles;


### PR DESCRIPTION
Deprecate the following:

- borderInlineEndWidth
- borderInlineStartWidth
- marginInlineEnd
- marginInlineStart
- paddingInlineEnd
- paddingInlineStart

The native equivalent of each of these have been supported by all major
browsers (excluding IE) since 2019.

Closes #15