### PR TITLE
Remove deprecation console.infos

### DIFF
--- a/src/borderInlineEndWidth.ts
+++ b/src/borderInlineEndWidth.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with native border-inline-end-width.
  * @public
  */
-const borderInlineEndWidth = (value: string): SerializedStyles => {
-  console.info(
-    "borderInlineEndWidth is deprecated due to pervasive browser support for the native border-inline-end-width property. Please replace with border-inline-end-width."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      border-right-width: ${value};
-    }
-    html[dir="rtl"] & {
-      border-left-width: ${value};
-    }
-  `;
-};
+const borderInlineEndWidth = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    border-right-width: ${value};
+  }
+  html[dir="rtl"] & {
+    border-left-width: ${value};
+  }
+`;
 
 export default borderInlineEndWidth;

--- a/src/borderInlineStartWidth.ts
+++ b/src/borderInlineStartWidth.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with native border-inline-start-width.
  * @public
  */
-const borderInlineStartWidth = (value: string): SerializedStyles => {
-  console.info(
-    "borderInlineStartWidth is deprecated due to pervasive browser support for the native border-inline-start-width property. Please replace with border-inline-start-width."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      border-left-width: ${value};
-    }
-    html[dir="rtl"] & {
-      border-right-width: ${value};
-    }
-  `;
-};
+const borderInlineStartWidth = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    border-left-width: ${value};
+  }
+  html[dir="rtl"] & {
+    border-right-width: ${value};
+  }
+`;
 
 export default borderInlineStartWidth;

--- a/src/marginInlineEnd.ts
+++ b/src/marginInlineEnd.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with native margin-inline-end.
  * @public
  */
-const marginInlineEnd = (value: string): SerializedStyles => {
-  console.info(
-    "marginInlineEnd is deprecated due to pervasive browser support for the native margin-inline-end property. Please replace with margin-inline-end."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      margin-right: ${value};
-    }
-    html[dir="rtl"] & {
-      margin-left: ${value};
-    }
-  `;
-};
+const marginInlineEnd = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    margin-right: ${value};
+  }
+  html[dir="rtl"] & {
+    margin-left: ${value};
+  }
+`;
 
 export default marginInlineEnd;

--- a/src/marginInlineStart.ts
+++ b/src/marginInlineStart.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with margin-inline-start.
  * @public
  */
-const marginInlineStart = (value: string): SerializedStyles => {
-  console.info(
-    "marginInlineStart is deprecated due to pervasive browser support for the native margin-inline-start property. Please replace with margin-inline-start."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      margin-left: ${value};
-    }
-    html[dir="rtl"] & {
-      margin-right: ${value};
-    }
-  `;
-};
+const marginInlineStart = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    margin-left: ${value};
+  }
+  html[dir="rtl"] & {
+    margin-right: ${value};
+  }
+`;
 
 export default marginInlineStart;

--- a/src/paddingInlineEnd.ts
+++ b/src/paddingInlineEnd.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with native padding-inline-end.
  * @public
  */
-const paddingInlineEnd = (value: string): SerializedStyles => {
-  console.info(
-    "paddingInlineEnd is deprecated due to pervasive browser support for the native padding-inline-end property. Please replace with padding-inline-end."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      padding-right: ${value};
-    }
-    html[dir="rtl"] & {
-      padding-left: ${value};
-    }
-  `;
-};
+const paddingInlineEnd = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    padding-right: ${value};
+  }
+  html[dir="rtl"] & {
+    padding-left: ${value};
+  }
+`;
 
 export default paddingInlineEnd;

--- a/src/paddingInlineStart.ts
+++ b/src/paddingInlineStart.ts
@@ -8,19 +8,13 @@ import { css, SerializedStyles } from "@emotion/react";
  * @deprecated Should be replaced with native padding-inline-start.
  * @public
  */
-const paddingInlineStart = (value: string): SerializedStyles => {
-  console.info(
-    "paddingInlineStart is deprecated due to pervasive browser support for the native padding-inline-start property. Please replace with padding-inline-start."
-  );
-
-  return css`
-    html[dir="ltr"] & {
-      padding-left: ${value};
-    }
-    html[dir="rtl"] & {
-      padding-right: ${value};
-    }
-  `;
-};
+const paddingInlineStart = (value: string): SerializedStyles => css`
+  html[dir="ltr"] & {
+    padding-left: ${value};
+  }
+  html[dir="rtl"] & {
+    padding-right: ${value};
+  }
+`;
 
 export default paddingInlineStart;


### PR DESCRIPTION
These are redundant since VS Code marks deprecated functions.

Closes #19